### PR TITLE
feat(dashboard): create resusable Widget card [#19]

### DIFF
--- a/client/src/components/dashboard/WidgetCard.tsx
+++ b/client/src/components/dashboard/WidgetCard.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+interface WidgetCardProps {
+  title: string;
+  children: React.ReactNode;
+  onMoreOptions?: () => void;
+}
+
+const WidgetCard: React.FC<WidgetCardProps> = ({
+  title,
+  children,
+  onMoreOptions,
+}) => {
+  return (
+    <div className="bg-neutral-white dark:bg-neutral-dark2 p-6 rounded-xl shadow-md border border-neutral-softGrey1 dark:border-neutral-grey1">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-neutral-dark1 dark:text-neutral-white">
+          {title}
+        </h3>
+
+        {/* More options button */}
+        <button
+          onClick={onMoreOptions}
+          className="p-2 rounded-lg hover:bg-neutral-softGrey1 dark:hover:bg-neutral-grey1 transition-colors duration-200 text-neutral-grey2 dark:text-neutral-grey3 hover:text-neutral-dark1 dark:hover:text-neutral-white"
+          aria-label="More options"
+        >
+          <svg
+            className="w-5 h-5"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M10 6a2 2 0 110-4 2 2 0 010 4zM10 12a2 2 0 110-4 2 2 0 010 4zM10 18a2 2 0 110-4 2 2 0 010 4z" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="text-neutral-dark2 dark:text-neutral-grey3">
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default WidgetCard;


### PR DESCRIPTION
### 📋 Description

This PR introduces the new, reusable `WidgetCard` component, which will serve as the standard container for all widgets on the main dashboard. This foundational component provides a consistent look and feel, including a header with a title and a "more options" button.

### ✅ Key Changes
- **Component Creation:** Built the `WidgetCard` component at `src/components/dashboard/WidgetCard.tsx`.
- **Props-Based Design:** The component accepts a `title` and `children` props, making it flexible and easy to use for wrapping any dashboard content.
- **Consistent Header:** Implemented the standard widget header with a title on the left and a "more options" (three dots) icon on the right.
- **Theming:** The component is fully theme-aware, using the project's color palette to support both light and dark modes perfectly.

Closes #19