### PR TITLE
feat(ui):create reusable CategoryChip component [#39]

### DIFF
--- a/client/src/components/ui/CategoryChip.tsx
+++ b/client/src/components/ui/CategoryChip.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import clsx from "clsx";
+
+type Props = {
+  label: string;
+  icon: React.ReactNode;
+  selected?: boolean;
+  onClick?: () => void;
+  className?: string;
+};
+const CategoryChip = ({
+  label,
+  icon,
+  selected = false,
+  onClick,
+  className,
+}: Props) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={clsx(
+        "inline-flex items-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition-colors",
+        "focus:outline-none focus:ring-2 focus:ring-primary-brand/60 focus:ring-offset-2",
+        "dark:focus:ring-offset-neutral-dark2",
+        selected
+          ? "bg-primary-brand text-black border-primary-brand"
+          : "bg-neutral-white dark:bg-neutral-dark2 text-neutral-dark1 dark:text-neutral-white border-neutral-softGrey1 dark:border-neutral-grey1 hover:bg-neutral-softGrey1 dark:hover:bg-neutral-dark1",
+        className
+      )}
+    >
+      <span className="text-base leading-none">{icon}</span>
+      <span className="leading-none">{label}</span>
+    </button>
+  );
+};
+
+export default CategoryChip;


### PR DESCRIPTION
### 📋 Description

This PR introduces the new, reusable `CategoryChip` component. This is a foundational UI element that will be used in forms across the application (like "Add Expense" and "Add Income") for selecting categories.

### ✅ Key Changes
- **Component Creation:** Built the `CategoryChip` component at `src/components/ui/CategoryChip.tsx`.
- **Props-Based Design:** The component accepts props for a `label`, `icon`, and `isSelected` to make it flexible and reusable.
- **State Variants:** Implemented both a default (unselected) and a `selected` visual state to provide clear feedback to the user.
- **Theming:** The component is fully theme-aware and styled using the project's color palette, ensuring it works perfectly in both light and dark modes.

Closes #39