### PR TITLE
feat(ui): create generic Modal and Toast components [#41]

### DIFF
--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect } from "react";
+import clsx from "clsx";
+
+type ModalProps = {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+};
+
+const Modal: React.FC<ModalProps> = ({
+  open,
+  onClose,
+  title,
+  children,
+  actions,
+  className,
+}) => {
+  useEffect(() => {
+    if (!open) return;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleEsc);
+    return () => window.removeEventListener("keydown", handleEsc);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60">
+      <div
+        className={clsx(
+          "bg-neutral-white dark:bg-neutral-dark2 rounded-xl shadow-xl p-6 w-full max-w-md mx-4",
+          className
+        )}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+      >
+        {title && (
+          <h2 className="text-lg font-semibold mb-4 text-neutral-dark1 dark:text-neutral-white">
+            {title}
+          </h2>
+        )}
+        <div>{children}</div>
+        {actions && (
+          <div className="mt-6 flex justify-end gap-2">{actions}</div>
+        )}
+      </div>
+      {/* Overlay click closes modal */}
+      <div className="fixed inset-0" onClick={onClose} />
+    </div>
+  );
+};
+
+export default Modal;

--- a/client/src/components/ui/Toast.tsx
+++ b/client/src/components/ui/Toast.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from "react";
+import clsx from "clsx";
+import { CheckCircle, Info, XCircle } from "lucide-react";
+
+type ToastProps = {
+  open: boolean;
+  message: string;
+  type?: "success" | "error" | "info";
+  duration?: number;
+  onClose: () => void;
+};
+
+const typeStyles = {
+  success: "bg-primary-dark text-white border-primary-dark",
+  error: "bg-system-red text-white border-system-red",
+  info: "bg-system-green text-black border-system-green",
+};
+
+const typeIcons = {
+  success: <CheckCircle className="w-5 h-5 mr-2" />,
+  error: <XCircle className="w-5 h-5 mr-2" />,
+  info: <Info className="w-5 h-5 mr-2" />,
+};
+
+const Toast: React.FC<ToastProps> = ({
+  open,
+  message,
+  type = "info",
+  duration = 3000,
+  onClose,
+}) => {
+  const [visible, setVisible] = useState(open);
+
+  useEffect(() => {
+    setVisible(open);
+    if (open) {
+      const timer = setTimeout(() => {
+        setVisible(false);
+        setTimeout(onClose, 300); // Wait for transition to finish
+      }, duration);
+      return () => clearTimeout(timer);
+    }
+  }, [open, duration, onClose]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className={clsx(
+        // Responsive bottom: more space on mobile for navbar
+        "fixed bottom-20 sm:bottom-8 left-1/2 z-50 -translate-x-1/2 px-2 w-full flex justify-center",
+        "transition-all duration-300 ease-in-out",
+        open
+          ? "opacity-100 translate-y-0 pointer-events-auto"
+          : "opacity-0 translate-y-8 pointer-events-none"
+      )}
+    >
+      <div
+        className={clsx(
+          "flex items-center gap-2 px-5 py-3 rounded-xl shadow-xl border font-semibold text-base",
+          "dark:shadow-black/40",
+          "w-full max-w-xs sm:max-w-md",
+          typeStyles[type]
+        )}
+        role="status"
+        aria-live="polite"
+      >
+        {typeIcons[type]}
+        <span>{message}</span>
+      </div>
+    </div>
+  );
+};
+
+export default Toast;


### PR DESCRIPTION
### 📋 Description

This PR introduces two foundational UI components, `Modal` and `Toast`, based on the Figma designs. These components are essential for providing user feedback and handling confirmation dialogs throughout the application.

### ✅ Key Changes
- **Component Creation:** Built the reusable `Modal.tsx` and `Toast.tsx` components and placed them in `src/components/ui`.
- **Programmatic Control:** Both components are designed to be triggered programmatically via React state, allowing for flexible use across different features.
- **Theming:** The components are fully theme-aware, with styles for both light and dark modes that are consistent with the project's design system.
- **Reusability:** These generic components are now part of the core UI library and can be used anywhere in the application for a consistent user experience.

Closes #41 