### PR TITLE
feat(reminder): Implemented reminder page [#40]

### DIFF
--- a/client/src/app/(app)/cards/page.tsx
+++ b/client/src/app/(app)/cards/page.tsx
@@ -1,3 +1,0 @@
-export default function CardsPage() {
-  return <div className="p-6">Cards</div>;
-}

--- a/client/src/app/(app)/reminder/page.tsx
+++ b/client/src/app/(app)/reminder/page.tsx
@@ -1,0 +1,38 @@
+import ListItem from "@/components/ui/ListItem";
+
+interface RemindersListProps {
+  onAddReminderClick: () => void;
+}
+
+export default function RemindersList({ onAddReminderClick }: RemindersListProps) {
+  const reminders = [
+    { topic: "Pay Electricity Bill", description: "Due soon", rightLabel: "Aug 20, 2025" },
+    { topic: "Doctor Appointment", description: "Health Checkup", rightLabel: "Aug 22, 2025" }
+  ];
+
+  return (
+    <div>
+      <div className="flex justify-end mb-4">
+        <button
+          onClick={onAddReminderClick}
+          className="bg-primary-dark text-white px-4 py-2 rounded-lg hover:bg-primary-dark"
+        >
+          + Set Reminder
+        </button>
+      </div>
+
+      <div className="space-y-4 ">
+        {reminders.map((reminder, index) => (
+          <ListItem
+            key={index}
+            variant="reminder"
+            title={reminder.topic}
+            description={reminder.description}
+            rightLabel={reminder.rightLabel}
+            
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/nav/LeftNavBar.tsx
+++ b/client/src/components/nav/LeftNavBar.tsx
@@ -1,23 +1,23 @@
-'use client'
+'use client';
 
-import Link from 'next/link'
-import { usePathname } from 'next/navigation'
-import { appNav } from '@/config/nav'
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { appNav } from '@/config/nav';
 
 type DesktopSidebarProps = {
   isOpen: boolean;
   onMouseLeave: () => void;
+  onReminderClick?: () => void; // Callback from parent
 };
 
-export default function DesktopSidebar({ isOpen, onMouseLeave }: DesktopSidebarProps) {
+export default function DesktopSidebar({ isOpen, onMouseLeave, onReminderClick }: DesktopSidebarProps) {
   const pathname = usePathname();
 
   return (
-    <div className="hidden md:flex"onMouseLeave={onMouseLeave}>
-      {/* The toggle button has been removed from here */}
+    <div className="hidden md:flex" onMouseLeave={onMouseLeave}>
       <aside
         className={`
-         w-64 h-screen bg-neutral-white dark:bg-secondary-darkBrand border-r shadow-md space-y-6 fixed top-0 left-0 z-40
+          w-64 h-screen bg-neutral-white dark:bg-secondary-darkBrand border-r shadow-md space-y-6 fixed top-0 left-0 z-40
           transition-all duration-300
           ${isOpen ? 'translate-x-0' : '-translate-x-full'}
         `}
@@ -39,10 +39,19 @@ export default function DesktopSidebar({ isOpen, onMouseLeave }: DesktopSidebarP
         <nav className="flex flex-col gap-4 p-4 mt-2">
           {appNav.map(({ label, href, icon: Icon }) => {
             const isActive = pathname === href || pathname.startsWith(href + '/');
+
+            const handleClick = (e: React.MouseEvent) => {
+              if (label === "Reminder" && onReminderClick) {
+                e.preventDefault(); // Prevent navigation
+                onReminderClick(); // Call parent function
+              }
+            };
+
             return (
               <Link
                 key={href}
                 href={href}
+                onClick={handleClick}
                 className={`flex items-center gap-3 px-4 py-2 rounded-md transition text-xl
                   ${isActive
                     ? 'bg-primary-dark text-secondary-darkBrand dark:text-neutral-white'

--- a/client/src/components/nav/Navigation.tsx
+++ b/client/src/components/nav/Navigation.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { ReactNode } from "react";
+import { ReactNode, useState } from "react";
 import { usePathname } from "next/navigation";
 import LeftNavBar from "./LeftNavBar";
 import BottomNavBar from "./BottomNavBar";
 import { TopAppBar } from "./Topbar";
 import { useNavigation } from "@/hooks/useNavigation";
 import { titleForPathname } from "@/config/nav";
+import ReminderList from "@/app/(app)/reminder/page";
+import SetReminder from "@/components/reminder/setReminder";
 
 interface NavigationProps {
   children: ReactNode;
@@ -17,9 +19,25 @@ const Navigation: React.FC<NavigationProps> = ({ children }) => {
   const { isMobileView, isSidebarOpen, togglePin, setHoverOpen } = useNavigation();
   const currentPageTitle = titleForPathname(pathname);
 
+  // Manage which view to show
+  const [activeView, setActiveView] = useState<"dashboard" | "reminders" | "addReminder">("dashboard");
+
+  // Sidebar click triggers reminder view
+  const handleReminderClick = () => {
+    setActiveView("reminders");
+  };
+
+  const goToAddReminder = () => {
+    setActiveView("addReminder");
+  };
+
+  const goBackToReminders = () => {
+    setActiveView("reminders");
+  };
 
   return (
     <div className="bg-neutral-white dark:bg-secondary-darkBrand min-h-screen">
+      {/* Sidebar hover trigger for desktop */}
       {!isMobileView && (
         <div
           onMouseEnter={() => setHoverOpen(true)}
@@ -27,22 +45,44 @@ const Navigation: React.FC<NavigationProps> = ({ children }) => {
         />
       )}
 
-  <LeftNavBar isOpen={isSidebarOpen} onMouseLeave={() => setHoverOpen(false)} />
-      
+      {/* Left Sidebar with reminder handler */}
+      <LeftNavBar
+        isOpen={isSidebarOpen}
+        onMouseLeave={() => setHoverOpen(false)}
+        onReminderClick={handleReminderClick}
+      />
+
       <div className={`relative transition-all duration-300 ease-in-out ${isSidebarOpen ? 'md:ml-64' : 'ml-0'}`}>
-        <TopAppBar 
-          variant={isMobileView ? 'back' : 'default'} 
-          title={currentPageTitle}
-          onToggleSidebar={togglePin} 
-          isSidebarOpen={isSidebarOpen} 
+        {/* Top Bar */}
+        <TopAppBar
+          variant={isMobileView ? 'back' : 'default'}
+          title={
+            activeView === "dashboard"
+              ? currentPageTitle
+              : activeView === "reminders"
+              ? "Reminders"
+              : "Set Reminder"
+          }
+          onToggleSidebar={togglePin}
+          isSidebarOpen={isSidebarOpen}
         />
-        
-        <main className="pt-16">
-          {children}
+
+        {/* Main Content */}
+        <main className="pt-16 p-4">
+          {activeView === "dashboard" && children}
+
+          {activeView === "reminders" && (
+            <ReminderList onAddReminderClick={goToAddReminder} />
+          )}
+
+          {activeView === "addReminder" && (
+            <SetReminder onBack={goBackToReminders} />
+          )}
         </main>
       </div>
-      
-  <BottomNavBar />
+
+      {/* Bottom Nav for Mobile */}
+      <BottomNavBar />
     </div>
   );
 };

--- a/client/src/components/nav/Topbar.tsx
+++ b/client/src/components/nav/Topbar.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Bell, Menu, MoreVertical, Search, X } from "lucide-react";
+import { ArrowLeft, Bell, Menu, MoreVertical, Search, X,CalendarClock } from "lucide-react";
 import { useState } from "react";
 import { useRouter } from "next/navigation";
  
@@ -7,6 +7,7 @@ type TopAppBarProps = {
   title: string;
   onToggleSidebar?: () => void;
   isSidebarOpen?: boolean;
+  
 };
 
 export const TopAppBar = ({ variant = 'default', title, onToggleSidebar, isSidebarOpen }: TopAppBarProps) => {
@@ -15,8 +16,10 @@ export const TopAppBar = ({ variant = 'default', title, onToggleSidebar, isSideb
 
   const handleLogout = () => console.log('Logging out...');
   const handleHelp = () => console.log('Navigating to Help & Support...');
-  const handleBack = () => router.back();
+  const handleBack = () => window.history.back();
   const handleSearch = () =>  console.log('Opening search...'); 
+  
+
   
 
   return (
@@ -64,6 +67,7 @@ export const TopAppBar = ({ variant = 'default', title, onToggleSidebar, isSideb
             >
               <Bell className="w-5 h-5" />
             </button>
+            
             <div className="relative">
               <button
                 onClick={() => setMenuOpen(!menuOpen)}
@@ -83,6 +87,7 @@ export const TopAppBar = ({ variant = 'default', title, onToggleSidebar, isSideb
                         Help & Support
                       </button>
                     </li>
+                    
                     <li>
                       <button
                         onClick={handleLogout}

--- a/client/src/components/ui/ListItem.tsx
+++ b/client/src/components/ui/ListItem.tsx
@@ -151,7 +151,8 @@ const ListItem: React.FC<ListItemProps> = ({
   // Reminder Variant
   if (variant === "reminder") {
     return (
-      <div className={baseContainerClasses}>
+      <div className={`${baseContainerClasses} gap-2 shadow-md border border-neutral-softGrey1 p-2 rounded-lg dark:border-none`}
+>
         <div className="flex justify-between items-start gap-4">
           <div className="flex flex-col min-w-0">
             {" "}


### PR DESCRIPTION
##Description
Clicking Reminder in the Left Sidebar currently navigates to a separate /reminder route.
The expected behaviour is to toggle the view inside the existing layout without route changes.
The application should allow switching between Dashboard, Reminder List, and Add Reminder views dynamically.
The Top Bar title should update based on the active view:
Dashboard → Current page title.
Reminder List → “Reminders”.
Add Reminder → “Set Reminder”.
This interaction should work seamlessly across desktop (with sidebar) and mobile (with bottom navigation).
The goal is to maintain a single-page experience without page reloads.

closes #40 