### PR TITLE
fix(reminder): Set reminder page added [#40]

### DIFF
--- a/client/src/app/(app)/reminder/add/page.tsx
+++ b/client/src/app/(app)/reminder/add/page.tsx
@@ -1,0 +1,16 @@
+import SetReminder from "@/components/reminder/setReminder";
+import React from "react";
+import AddGoalPage from "../../goals/add/page";
+
+type Props = {};
+
+const AddReminderPage = (props: Props) => {
+  return (
+     <div className="p-4">
+      <h1 className="text-xl font-semibold mb-4">Add Reminder</h1>
+      <SetReminder />
+    </div>
+  );
+};
+
+export default AddReminderPage;

--- a/client/src/app/(app)/reminder/page.tsx
+++ b/client/src/app/(app)/reminder/page.tsx
@@ -1,27 +1,41 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
 import ListItem from "@/components/ui/ListItem";
+import Button from "@/components/ui/Button";
+import Modal from "@/components/ui/Modal";
+import SetReminder from "@/components/reminder/setReminder"; 
+import MobileView from "@/hooks/mobileView"; // custom hook from step 1
 
-interface RemindersListProps {
-  onAddReminderClick: () => void;
-}
+interface RemindersListProps {}
 
-export default function RemindersList({ onAddReminderClick }: RemindersListProps) {
+export default function RemindersList({}: RemindersListProps) {
+  const router = useRouter();
+  const isMobile = MobileView();
+  const [openModal, setOpenModal] = useState(false);
+
   const reminders = [
     { topic: "Pay Electricity Bill", description: "Due soon", rightLabel: "Aug 20, 2025" },
     { topic: "Doctor Appointment", description: "Health Checkup", rightLabel: "Aug 22, 2025" }
   ];
 
+  const handleAddClick = () => {
+    if (isMobile) {
+      router.push("/reminder/add"); // separate page on mobile
+    } else {
+      setOpenModal(true); // modal on desktop
+    }
+  };
+
   return (
     <div>
       <div className="flex justify-end mb-4">
-        <button
-          onClick={onAddReminderClick}
-          className="bg-primary-dark text-white px-4 py-2 rounded-lg hover:bg-primary-dark"
-        >
+        <Button variant="primary" onClick={handleAddClick}>
           + Set Reminder
-        </button>
+        </Button>
       </div>
 
-      <div className="space-y-4 ">
+      <div className="space-y-4">
         {reminders.map((reminder, index) => (
           <ListItem
             key={index}
@@ -29,10 +43,16 @@ export default function RemindersList({ onAddReminderClick }: RemindersListProps
             title={reminder.topic}
             description={reminder.description}
             rightLabel={reminder.rightLabel}
-            
           />
         ))}
       </div>
+
+      {/* Modal only for desktop */}
+      {!isMobile && (
+        <Modal open={openModal} onClose={() => setOpenModal(false)} title="Add Reminder" className="p-7">
+          <SetReminder />
+        </Modal>
+      )}
     </div>
   );
 }

--- a/client/src/components/nav/Navigation.tsx
+++ b/client/src/components/nav/Navigation.tsx
@@ -20,21 +20,11 @@ const Navigation: React.FC<NavigationProps> = ({ children }) => {
   const currentPageTitle = titleForPathname(pathname);
 
   // Manage which view to show
-  const [activeView, setActiveView] = useState<"dashboard" | "reminder" | "addReminder">("dashboard");
+  const [activeView, setActiveView] = useState("dashboard");
 
   // Sidebar click triggers reminder view
-  const handleReminderClick = () => {
-    setActiveView("reminder");
-  };
 
-  const goToAddReminder = () => {
-    setActiveView("addReminder");
-  };
 
-  const goBackToReminders = () => {
-    setActiveView("reminder");
-  };
-  {console.log(activeView)}
   return (
     <div className="bg-neutral-white dark:bg-secondary-darkBrand min-h-screen">
       {/* Sidebar hover trigger for desktop */}
@@ -49,7 +39,7 @@ const Navigation: React.FC<NavigationProps> = ({ children }) => {
       <LeftNavBar
         isOpen={isSidebarOpen}
         onMouseLeave={() => setHoverOpen(false)}
-        onReminderClick={handleReminderClick}
+   
       />
 
       <div className={`relative transition-all duration-300 ease-in-out ${isSidebarOpen ? 'md:ml-64' : 'ml-0'}`}>
@@ -72,13 +62,9 @@ const Navigation: React.FC<NavigationProps> = ({ children }) => {
         <main className="pt-16 p-4">
           {activeView === "dashboard" && children}
 
-          {activeView === "reminder" && (
-            <ReminderList onAddReminderClick={goToAddReminder} />
-          )}
+          
 
-          {activeView === "addReminder" && (
-            <SetReminder onBack={goBackToReminders} />
-          )}
+          
         </main>
       </div>
 

--- a/client/src/components/reminder/setReminder.tsx
+++ b/client/src/components/reminder/setReminder.tsx
@@ -1,0 +1,101 @@
+"use client";
+import React, { useState } from "react";
+import { Calendar as CalendarIcon } from "lucide-react";
+import { format } from "date-fns";
+import FormInput from "../ui/FormInput";
+import Button from "../ui/Button";
+import Calendar from "../ui/calendar";
+import Modal from "../ui/Modal";
+
+const contributionOptions = [
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+  { value: "yearly", label: "Yearly" },
+];
+
+function formatAmountInput(v: string) {
+  const digits = v.replace(/[^\d]/g, "");
+  if (!digits) return "";
+  return Number(digits).toLocaleString("en-IN");
+}
+
+const SetReminder = () => {
+  const [title, setTitle] = useState("");
+  const [amount, setAmount] = useState("");
+  const [contribution, setContribution] = useState<string | null>("yearly");
+  const [deadline, setDeadline] = useState<Date | null>(null);
+  const [openCal, setOpenCal] = useState(false);
+
+  const contributionLabel =
+    contributionOptions.find((o) => o.value === contribution)?.label ?? "";
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    // submit values: { title, amount, contribution, deadline }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="flex flex-col gap-6">
+        <FormInput
+          label="Reminder Title"
+          placeholder="Enter your reminder title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        <FormInput
+          label="Amount"
+          placeholder="0"
+          value={amount}
+          onChange={(e) => setAmount(formatAmountInput(e.target.value))}
+          inputMode="numeric"
+          suffixText="$"
+        />
+
+        <FormInput
+          label="Frequency"
+          placeholder="Select"
+          value={contributionLabel}
+          readOnly
+          hasDropdown
+          dropdownOptions={contributionOptions}
+          onDropdownSelect={(val) => setContribution(val)}
+        />
+
+        {/* Deadline with Calendar in Modal */}
+        <FormInput
+          label="Deadline"
+          placeholder="MM/DD/YYYY"
+          value={deadline ? format(deadline, "MM/dd/yyyy") : ""}
+          readOnly
+          trailingIcon={<CalendarIcon size={18} />}
+          onTrailingClick={() => setOpenCal(true)}
+          onClick={() => setOpenCal(true)}
+        />
+
+        <Modal
+          className="md:w-[24rem]"
+          open={openCal}
+          onClose={() => setOpenCal(false)}
+        >
+          {/* No extra stopPropagation wrapper needed */}
+          <Calendar
+            variant="picker"
+            value={deadline ?? new Date()}
+            onChange={(d: Date) => {
+              setDeadline(d);
+              setOpenCal(false);
+            }}
+          />
+        </Modal>
+      </div>
+
+      <Button type="submit" className="w-full">
+        ADD REMINDER
+      </Button>
+    </form>
+  );
+};
+export default SetReminder;

--- a/client/src/config/nav.ts
+++ b/client/src/config/nav.ts
@@ -8,6 +8,7 @@ export const appNav = [
   { label: "Reminder", href: "/reminder", icon: CreditCard },
   { label: "Budget", href: "/budget", icon: DollarSign },
   { label: "Preferences", href: "/preferences", icon: Settings },
+  { label: "Savings", href: "/savings", icon: DollarSign }
 
 ] as const;
 

--- a/client/src/hooks/mobileView.tsx
+++ b/client/src/hooks/mobileView.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+export default function MobileView() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkSize = () => setIsMobile(window.innerWidth < 768); 
+    checkSize();
+    window.addEventListener("resize", checkSize);
+    return () => window.removeEventListener("resize", checkSize);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
**Description : **
This update adds responsive behavior for creating reminders. On desktop screens, clicking + Set Reminder opens the SetReminder form in a modal for a seamless experience. On mobile devices, the button navigates to a dedicated page at /reminder/add showing the same form in full view. A custom hook is used to detect screen size and conditionally render the modal or redirect. This improves usability and ensures a consistent, responsive design across devices.

closes #40 