### PR TITLE
Feat/be categories

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -6,7 +6,7 @@ import health from "./routes/health";
 import auth from "./routes/auth";
 import {userRoutes} from "./routes/user";
 import {userRoute} from "./routes/user";
-import {categoryroutes} from "./routes/categories";
+import {categoryRoutes} from "./routes/categories";
 export function buildApp() {
   const app = Fastify({
     logger: {
@@ -38,6 +38,6 @@ export function buildApp() {
   app.register(auth, { prefix: "/auth" });
   app.register(userRoutes, { prefix: "/user" });
   app.register(userRoute, { prefix: "/user" });
-  app.register(categoryroutes);
+  app.register(categoryRoutes);
   return app;
 }

--- a/server/src/routes/categories.ts
+++ b/server/src/routes/categories.ts
@@ -4,7 +4,7 @@ import { createCategorySchema , getCategorySchema , patchCategorySchema, deleteC
 
 const prisma = new PrismaClient();
 
-export const categoryroutes : FastifyPluginAsync = async (fastify,_optioins) =>{
+export const categoryRoutes : FastifyPluginAsync = async (fastify,_options) =>{
     fastify.post("/categories",{
         preHandler : [(fastify as any).authenticate]},async (request:FastifyRequest<{
             Body : {
@@ -12,124 +12,148 @@ export const categoryroutes : FastifyPluginAsync = async (fastify,_optioins) =>{
                 type: "INCOME" | "EXPENSE"
             }
         }> ,reply)=>{
-            
-            const {name,type} = request.body;
-            const userid = (request.user as any).userId;
-           
-
-            const category = await prisma.categories.create({
-                data : {
+            try {
+                const {name,type} = request.body;
+                const userId = (request.user as any).userId;
+                
+                // Validate request body before database operation
+                const validation = createCategorySchema.safeParse({
                     name,
                     type,
-                    userId : userid
+                    userId
+                });
+                
+                if(!validation.success){
+                    return reply.code(400).send({
+                        error : validation.error.format(),
+                    })
                 }
-            })
-            const validation = createCategorySchema.safeParse(category);
-            console.log("validation", validation)
-            if(!validation.success){
-                return reply.code(400).send({
-                    error : validation.error.format(),
+
+                const category = await prisma.categories.create({
+                    data : {
+                        name,
+                        type,
+                        userId
+                    }
                 })
                 
+                reply.send("Database entry created: " + category.type + " - " + category.name)
+            } catch (error) {
+                console.error("Error creating category:", error);
+                return reply.code(500).send({ error: "Failed to create category" });
             }
-            reply.send("Databse entry created"+category.type + " " + category.name)
-
-
         }
     )
     fastify.get("/categories",{preHandler : [(fastify as any).authenticate]},async(request:FastifyRequest,reply)=>{
-        const userId = (request.user as any).userId;
-        const category = await prisma.categories.findMany({
-            where : {
-                userId : userId
-            },
-            select : {
-                userId : true,
-                name : true,
-                type : true,
-                id : true,
-                created_at : true,
-                user  : {
-                    select: {
-                        id : true,
-                        email : true,
-                        phone : true,
-                        profile_data : true
+        try {
+            const userId = (request.user as any).userId;
+            const category = await prisma.categories.findMany({
+                where : {
+                    userId : userId
+                },
+                select : {
+                    userId : true,
+                    name : true,
+                    type : true,
+                    id : true,
+                    created_at : true,
+                    user  : {
+                        select: {
+                            id : true,
+                            email : true,
+                            phone : true,
+                            profile_data : true
+                        }
                     }
                 }
-            }
-        })
-        if(!category){
-            return reply.code(404).send({error : "No categories found for this user"})
-        }
-        const validation = getCategorySchema.array().safeParse(category);
-        if(!validation.success){
-            return reply.code(400).send({
-                error : "Category data is invalid",
-                details : validation.error.format()
             })
-        }   
-        reply.send(category);
-
+            
+            if(category.length === 0){
+                return reply.code(404).send({error : "No categories found for this user"})
+            }
+            
+            const validation = getCategorySchema.array().safeParse(category);
+            if(!validation.success){
+                return reply.code(400).send({
+                    error : "Category data is invalid",
+                    details : validation.error.format()
+                })
+            }   
+            reply.send(category);
+        } catch (error) {
+            console.error("Error fetching categories:", error);
+            return reply.code(500).send({ error: "Failed to fetch categories" });
+        }
     })
 
     fastify.patch('/categories/:id',{ preHandler: [(fastify as any).authenticate] },async (request, reply) => {
+        try {
+            const validation = patchCategorySchema.safeParse(request.body);
+            if (!validation.success) {
+                return reply.code(400).send({
+                    error: 'Invalid data',
+                    details: validation.error.format(),
+                });
+            }
 
-    const validation = patchCategorySchema.safeParse(request.body);
-    if (!validation.success) {
-      return reply.code(400).send({
-        error: 'Invalid data',
-        details: validation.error.format(),
-      });
+            const { name, type } = validation.data;
+            const { id } = request.params as { id: string };
+            const userId = (request.user as any).userId;
+
+            const updated = await prisma.categories.updateMany({
+                where: {
+                    id,
+                    userId,
+                },
+                data: { name, type },
+            });
+
+            if (updated.count === 0) {
+                return reply.code(404).send({
+                    error: 'Category not found or not authorized',
+                });
+            }
+
+            return reply.send({ message: 'Category updated successfully' });
+        } catch (error) {
+            console.error("Error updating category:", error);
+            return reply.code(500).send({ error: "Failed to update category" });
+        }
     }
-
-    const { name, type } = validation.data;
-    const { id } = request.params as { id: string };
-    const userId = (request.user as any).id;
-
-    const updated = await prisma.categories.updateMany({
-      where: {
-        id,
-        userId,
-      },
-      data: { name, type },
-    });
-
-    if (updated.count === 0) {
-      return reply.code(404).send({
-        error: 'Category not found or not authorized',
-      });
-    }
-
-    return reply.send({ message: 'Category updated successfully' });
-  }
-);
+    );
 
 
     fastify.delete('/categories/:id',{ preHandler: [(fastify as any).authenticate] },async (request, reply) => {
-    const { id } = request.params as { id: string };
-    const userId = (request.user as any).id;
-    const parsedParams = deleteCategorySchema.safeParse({ id });
-    if (!parsedParams.success) {
-      return reply.code(400).send({
-        error: 'Invalid category id',
-        details: parsedParams.error.format(),
-      });
-    }
+        try {
+            const { id } = request.params as { id: string };
+            const userId = (request.user as any).userId;
+            
+            // Validate parameters before database operation
+            const parsedParams = deleteCategorySchema.safeParse({ id });
+            if (!parsedParams.success) {
+                return reply.code(400).send({
+                    error: 'Invalid category id',
+                    details: parsedParams.error.format(),
+                });
+            }
 
-    const result = await prisma.categories.deleteMany({
-      where: {
-        id,
-        userId,
-      },
-    });
+            const result = await prisma.categories.deleteMany({
+                where: {
+                    id,
+                    userId,
+                },
+            });
 
-    if (result.count === 0) {
-      return reply.code(404).send({
-        error: 'Category not found or not authorized',
-      });
-    }
+            if (result.count === 0) {
+                return reply.code(404).send({
+                    error: 'Category not found or not authorized',
+                });
+            }
 
-    return reply.send({ message: 'Category deleted successfully' });
-  })
+            return reply.send({ message: 'Category deleted successfully' });
+        } catch (error) {
+            console.error("Error deleting category:", error);
+            return reply.code(500).send({ error: "Failed to delete category" });
+        }
+    })
 }

--- a/server/src/routes/categories.ts
+++ b/server/src/routes/categories.ts
@@ -96,7 +96,7 @@ export const categoryRoutes : FastifyPluginAsync = async (fastify,_options) =>{
 
         const { name, type } = validation.data;
         const { id } = request.params as { id: string };
-        const userId = (request.user as any).id;
+        const userId = (request.user as any).userId;
 
         const updated = await prisma.categories.updateMany({
           where: {
@@ -124,7 +124,7 @@ export const categoryRoutes : FastifyPluginAsync = async (fastify,_options) =>{
     fastify.delete('/categories/:id',{ preHandler: [(fastify as any).authenticate] },async (request, reply) => {
     try {
         const { id } = request.params as { id: string };
-        const userId = (request.user as any).id;
+        const userId = (request.user as any).userId;
         const parsedParams = deleteCategorySchema.safeParse({ id });
         if (!parsedParams.success) {
           return reply.code(400).send({

--- a/server/src/routes/categories.ts
+++ b/server/src/routes/categories.ts
@@ -37,9 +37,9 @@ export const categoryRoutes : FastifyPluginAsync = async (fastify,_options) =>{
                     }
                 })
                 
-                reply.send("Database entry created: " + category.type + " - " + category.name)
+                reply.send(`Database entry created: ${category.type} - ${category.name}`)
             } catch (error) {
-                console.error("Error creating category:", error);
+                console.error("Error creating category");
                 return reply.code(500).send({ error: "Failed to create category" });
             }
         }
@@ -81,7 +81,7 @@ export const categoryRoutes : FastifyPluginAsync = async (fastify,_options) =>{
             }   
             reply.send(category);
         } catch (error) {
-            console.error("Error fetching categories:", error);
+            console.error("Error fetching categories");
             return reply.code(500).send({ error: "Failed to fetch categories" });
         }
     })
@@ -116,7 +116,7 @@ export const categoryRoutes : FastifyPluginAsync = async (fastify,_options) =>{
 
             return reply.send({ message: 'Category updated successfully' });
         } catch (error) {
-            console.error("Error updating category:", error);
+            console.error("Error updating category");
             return reply.code(500).send({ error: "Failed to update category" });
         }
     }
@@ -152,7 +152,7 @@ export const categoryRoutes : FastifyPluginAsync = async (fastify,_options) =>{
 
             return reply.send({ message: 'Category deleted successfully' });
         } catch (error) {
-            console.error("Error deleting category:", error);
+            console.error("Error deleting category");
             return reply.code(500).send({ error: "Failed to delete category" });
         }
     })

--- a/server/src/routes/categories.ts
+++ b/server/src/routes/categories.ts
@@ -4,7 +4,7 @@ import { createCategorySchema , getCategorySchema , patchCategorySchema, deleteC
 
 const prisma = new PrismaClient();
 
-export const categoryroutes : FastifyPluginAsync = async (fastify,_optioins) =>{
+export const categoryRoutes : FastifyPluginAsync = async (fastify,_options) =>{
     fastify.post("/categories",{
         preHandler : [(fastify as any).authenticate]},async (request:FastifyRequest<{
             Body : {
@@ -12,124 +12,144 @@ export const categoryroutes : FastifyPluginAsync = async (fastify,_optioins) =>{
                 type: "INCOME" | "EXPENSE"
             }
         }> ,reply)=>{
-            
-            const {name,type} = request.body;
-            const userid = (request.user as any).userId;
-           
+            try {
+                const {name,type} = request.body;
+                const userid = (request.user as any).userId;
 
-            const category = await prisma.categories.create({
-                data : {
+                // Validate request body before database operation
+                const validation = createCategorySchema.partial({ userId: true }).safeParse({
                     name,
                     type,
-                    userId : userid
+                    userId: userid
+                });
+                
+                if(!validation.success){
+                    return reply.code(400).send({
+                        error : validation.error.format(),
+                    })
                 }
-            })
-            const validation = createCategorySchema.safeParse(category);
-            console.log("validation", validation)
-            if(!validation.success){
-                return reply.code(400).send({
-                    error : validation.error.format(),
+
+                const category = await prisma.categories.create({
+                    data : {
+                        name,
+                        type,
+                        userId : userid
+                    }
                 })
                 
+                reply.send("Database entry created: " + category.type + " " + category.name)
+            } catch (error) {
+                console.error("Error creating category:", error);
+                return reply.code(500).send({ error: "Failed to create category" });
             }
-            reply.send("Databse entry created"+category.type + " " + category.name)
-
-
         }
     )
     fastify.get("/categories",{preHandler : [(fastify as any).authenticate]},async(request:FastifyRequest,reply)=>{
-        const userId = (request.user as any).userId;
-        const category = await prisma.categories.findMany({
-            where : {
-                userId : userId
-            },
-            select : {
-                userId : true,
-                name : true,
-                type : true,
-                id : true,
-                created_at : true,
-                user  : {
-                    select: {
-                        id : true,
-                        email : true,
-                        phone : true,
-                        profile_data : true
+        try {
+            const userId = (request.user as any).userId;
+            const category = await prisma.categories.findMany({
+                where : {
+                    userId : userId
+                },
+                select : {
+                    userId : true,
+                    name : true,
+                    type : true,
+                    id : true,
+                    created_at : true,
+                    user  : {
+                        select: {
+                            id : true,
+                            email : true,
+                            phone : true,
+                            profile_data : true
+                        }
                     }
                 }
-            }
-        })
-        if(!category){
-            return reply.code(404).send({error : "No categories found for this user"})
-        }
-        const validation = getCategorySchema.array().safeParse(category);
-        if(!validation.success){
-            return reply.code(400).send({
-                error : "Category data is invalid",
-                details : validation.error.format()
             })
-        }   
-        reply.send(category);
-
+            if(category.length === 0){
+                return reply.code(404).send({error : "No categories found for this user"})
+            }
+            const validation = getCategorySchema.array().safeParse(category);
+            if(!validation.success){
+                return reply.code(400).send({
+                    error : "Category data is invalid",
+                    details : validation.error.format()
+                })
+            }   
+            reply.send(category);
+        } catch (error) {
+            console.error("Error fetching categories:", error);
+            return reply.code(500).send({ error: "Failed to fetch categories" });
+        }
     })
 
     fastify.patch('/categories/:id',{ preHandler: [(fastify as any).authenticate] },async (request, reply) => {
+    try {
+        const validation = patchCategorySchema.safeParse(request.body);
+        if (!validation.success) {
+          return reply.code(400).send({
+            error: 'Invalid data',
+            details: validation.error.format(),
+          });
+        }
 
-    const validation = patchCategorySchema.safeParse(request.body);
-    if (!validation.success) {
-      return reply.code(400).send({
-        error: 'Invalid data',
-        details: validation.error.format(),
-      });
+        const { name, type } = validation.data;
+        const { id } = request.params as { id: string };
+        const userId = (request.user as any).id;
+
+        const updated = await prisma.categories.updateMany({
+          where: {
+            id,
+            userId,
+          },
+          data: { name, type },
+        });
+
+        if (updated.count === 0) {
+          return reply.code(404).send({
+            error: 'Category not found or not authorized',
+          });
+        }
+
+        return reply.send({ message: 'Category updated successfully' });
+    } catch (error) {
+        console.error("Error updating category:", error);
+        return reply.code(500).send({ error: "Failed to update category" });
     }
-
-    const { name, type } = validation.data;
-    const { id } = request.params as { id: string };
-    const userId = (request.user as any).id;
-
-    const updated = await prisma.categories.updateMany({
-      where: {
-        id,
-        userId,
-      },
-      data: { name, type },
-    });
-
-    if (updated.count === 0) {
-      return reply.code(404).send({
-        error: 'Category not found or not authorized',
-      });
-    }
-
-    return reply.send({ message: 'Category updated successfully' });
   }
 );
 
 
     fastify.delete('/categories/:id',{ preHandler: [(fastify as any).authenticate] },async (request, reply) => {
-    const { id } = request.params as { id: string };
-    const userId = (request.user as any).id;
-    const parsedParams = deleteCategorySchema.safeParse({ id });
-    if (!parsedParams.success) {
-      return reply.code(400).send({
-        error: 'Invalid category id',
-        details: parsedParams.error.format(),
-      });
+    try {
+        const { id } = request.params as { id: string };
+        const userId = (request.user as any).id;
+        const parsedParams = deleteCategorySchema.safeParse({ id });
+        if (!parsedParams.success) {
+          return reply.code(400).send({
+            error: 'Invalid category id',
+            details: parsedParams.error.format(),
+          });
+        }
+
+        const result = await prisma.categories.deleteMany({
+          where: {
+            id,
+            userId,
+          },
+        });
+
+        if (result.count === 0) {
+          return reply.code(404).send({
+            error: 'Category not found or not authorized',
+          });
+        }
+
+        return reply.send({ message: 'Category deleted successfully' });
+    } catch (error) {
+        console.error("Error deleting category:", error);
+        return reply.code(500).send({ error: "Failed to delete category" });
     }
-
-    const result = await prisma.categories.deleteMany({
-      where: {
-        id,
-        userId,
-      },
-    });
-
-    if (result.count === 0) {
-      return reply.code(404).send({
-        error: 'Category not found or not authorized',
-      });
-    }
-
-    return reply.send({ message: 'Category deleted successfully' });
   })
 }


### PR DESCRIPTION
This pull request improves the `categories` route handling in the backend by fixing naming inconsistencies, enhancing error handling, and correcting user ID usage. The most important changes are:

**Bug fixes and consistency:**
* Renamed `categoryroutes` to `categoryRoutes` for consistent naming in both the import and export statements, and updated its usage in `app.ts` to match. [[1]](diffhunk://#diff-5b0e08e087af9c408d01c7be69bec82f49dae228a86bfc5842164ee23fa7912aL9-R9) [[2]](diffhunk://#diff-5b0e08e087af9c408d01c7be69bec82f49dae228a86bfc5842164ee23fa7912aL41-R41) [[3]](diffhunk://#diff-2665471196d64a611b86607664b7639f2993069ad74c0637f9f6b8ceefddd4dcL7-R48)

**Error handling improvements:**
* Added comprehensive `try-catch` blocks to all category route handlers (`POST`, `GET`, `PATCH`, `DELETE`) to handle and log errors, returning appropriate HTTP 500 responses when exceptions occur. [[1]](diffhunk://#diff-2665471196d64a611b86607664b7639f2993069ad74c0637f9f6b8ceefddd4dcL7-R48) [[2]](diffhunk://#diff-2665471196d64a611b86607664b7639f2993069ad74c0637f9f6b8ceefddd4dcL73-R88) [[3]](diffhunk://#diff-2665471196d64a611b86607664b7639f2993069ad74c0637f9f6b8ceefddd4dcR116-R127) [[4]](diffhunk://#diff-2665471196d64a611b86607664b7639f2993069ad74c0637f9f6b8ceefddd4dcR150-R153)

**Validation and logic corrections:**
* Moved request body validation before database operations in the `POST /categories` route and fixed the validation logic to use a partial schema that omits `userId` from the client input.
* Corrected the check for empty category results in the `GET /categories` route to use `category.length === 0` instead of a falsy check.
* Fixed references to the user ID property from `id` to `userId` in the `PATCH` and `DELETE` category routes for consistency and correctness. [[1]](diffhunk://#diff-2665471196d64a611b86607664b7639f2993069ad74c0637f9f6b8ceefddd4dcL88-R99) [[2]](diffhunk://#diff-2665471196d64a611b86607664b7639f2993069ad74c0637f9f6b8ceefddd4dcR116-R127) [[3]](diffhunk://#diff-2665471196d64a611b86607664b7639f2993069ad74c0637f9f6b8ceefddd4dcR150-R153)