### PR TITLE
feat(reminders): implemented CRUD for reminders

### DIFF
--- a/server/prisma/migrations/20260315180808_create_reminder_table/migration.sql
+++ b/server/prisma/migrations/20260315180808_create_reminder_table/migration.sql
@@ -1,0 +1,20 @@
+-- CreateEnum
+CREATE TYPE "RepeatEnum" AS ENUM ('NONE', 'DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY');
+
+-- CreateTable
+CREATE TABLE "Reminder" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "note" TEXT,
+    "due_at" TIMESTAMPTZ(6) NOT NULL,
+    "repeat" "RepeatEnum" NOT NULL DEFAULT 'NONE',
+    "is_done" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL,
+
+    CONSTRAINT "Reminder_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Reminder" ADD CONSTRAINT "Reminder_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -17,6 +17,14 @@ enum TransactionType {
   EXPENSE
 }
 
+enum RepeatEnum {
+  NONE
+  DAILY
+  WEEKLY
+  MONTHLY
+  YEARLY
+}
+
 model User {
   id            String   @id @default(cuid())
   email         String   @unique
@@ -31,6 +39,7 @@ model User {
   categories Categories[]
   Transactions Transaction[]
   budgets Budget[]
+  reminders Reminder[]
 }
 
 model RefreshToken {
@@ -70,20 +79,32 @@ model Budget {
 
 model Transaction {
   id          String          @id @default(cuid())
-  user_id     String          // ← Changed from userId
+  user_id     String          
   user        User            @relation(fields: [user_id], references: [id], onDelete: Cascade)
-  category_id String          // ← Changed from categoryId
+  category_id String          
   category    Categories      @relation(fields: [category_id], references: [id], onDelete: Cascade)
   title       String
   amount      Decimal         @db.Decimal(14, 2)
   type        TransactionType
-  occurred_at DateTime        @db.Timestamptz(6) // ← Changed from occurredAt
+  occurred_at DateTime        @db.Timestamptz(6) 
   metadata    Json?
   note        String?
-  is_deleted  Boolean         @default(false)    // ← Changed from isDeleted
-  created_at  DateTime        @default(now()) @db.Timestamptz(6)  // ← Changed from createdAt
-  updated_at  DateTime        @updatedAt @db.Timestamptz(6)       // ← Changed from updatedAt
+  is_deleted  Boolean         @default(false)   
+  created_at  DateTime        @default(now()) @db.Timestamptz(6)  
+  updated_at  DateTime        @updatedAt @db.Timestamptz(6)      
 
-  @@index([user_id, occurred_at])  // ← Update index
-  @@index([user_id, category_id])  // ← Update index
+  @@index([user_id, occurred_at])
+  @@index([user_id, category_id]) 
+}
+model Reminder {
+  id          String    @id @default(uuid())
+  user_id     String
+  user        User      @relation(fields: [user_id], references: [id], onDelete: Cascade)
+  title       String
+  note        String?
+  due_at      DateTime  @db.Timestamptz(6)
+  repeat      RepeatEnum @default(NONE)
+  is_done     Boolean   @default(false)
+  created_at  DateTime  @default(now()) @db.Timestamptz(6)
+  updated_at  DateTime  @updatedAt @db.Timestamptz(6)
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -10,6 +10,7 @@ import { userRoute } from "./routes/user";
 import { categoryRoutes } from "./routes/categories";
 import { budgetRoutes } from "./routes/budgets";
 import transactionRoutes from "./routes/transaction";
+import reminderRoutes from "./routes/reminder";
 export function buildApp() {
   const app = Fastify({
     logger: {
@@ -44,5 +45,6 @@ export function buildApp() {
   app.register(categoryRoutes);
   app.register(budgetRoutes);
   app.register(transactionRoutes);
+  app.register(reminderRoutes);
   return app;
 }

--- a/server/src/routes/reminder.ts
+++ b/server/src/routes/reminder.ts
@@ -1,0 +1,149 @@
+import prisma from "../lib/prisma";
+import { FastifyPluginAsync } from "fastify";
+import { createReminderSchema } from "../schemas/reminder";
+
+const reminder: FastifyPluginAsync = async (fastify) => {
+  fastify.post(
+    "/reminders",
+    {
+      preHandler: [fastify.authenticate],
+    },
+    async (request, reply) => {
+      try {
+        const validation = createReminderSchema.safeParse(request.body);
+
+        if (!validation.success) {
+          return reply.code(400).send({
+            error: "Invalid request data",
+            details: validation.error.errors,
+          });
+        }
+
+        const { title, note, due_at, repeat, is_done } = validation.data;
+
+        const reminder = await prisma.reminder.create({
+          data: {
+            user_id: request.user!.userId,
+            title,
+            note,
+            due_at,
+            repeat,
+            is_done,
+          },
+        });
+
+        return reply.code(201).send({
+          message: "Reminder created successfully",
+          reminder,
+        });
+      } catch (err) {
+        fastify.log.error(err);
+        return reply.code(500).send({
+          error: "Internal Server Error",
+        });
+      }
+    },
+  );
+
+  fastify.get(
+    "/reminders",
+    {
+      preHandler: [fastify.authenticate],
+    },
+    async (request, reply) => {
+      try {
+        const reminders = await prisma.reminder.findMany({
+          where: {
+            user_id: request.user!.userId,
+          },
+        });
+
+        return reply.code(200).send({ reminders });
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.code(500).send({
+          error: "Internal Server Error",
+        });
+      }
+    },
+  );
+
+  fastify.patch(
+    "/reminders/:id",
+    {
+      preHandler: [fastify.authenticate],
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+
+        const reminder = await prisma.reminder.findFirst({
+          where: {
+            id,
+            user_id: request.user!.userId,
+          },
+        });
+
+        if (!reminder) {
+          return reply.code(404).send({ error: "Reminder not found." });
+        }
+
+        await prisma.reminder.update({
+          where: {
+            id,
+          },
+          data: {
+            is_done: !reminder.is_done,
+          },
+        });
+
+        return reply.code(200).send({
+          message: "Reminder updated successfully",
+          reminder_id: id,
+        });
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.code(500).send({ error: "Internal Server Error" });
+      }
+    },
+  );
+
+  fastify.delete(
+    "/reminders/:id",
+    {
+      preHandler: [fastify.authenticate],
+    },
+    async (request, reply) => {
+      try {
+        const { id } = request.params as { id: string };
+
+        const reminder = await prisma.reminder.findFirst({
+          where: {
+            id,
+            user_id: request.user!.userId,
+          },
+        });
+
+        if (!reminder) {
+          return reply.code(404).send({ error: "Reminder not found" });
+        }
+
+        await prisma.reminder.delete({
+          where: {
+            id,
+          },
+        });
+
+        return reply.code(200).send({
+          message: "Reminder delete successfully",
+          reminder_id: id,
+        });
+      } catch (error) {
+        fastify.log.error(error);
+        return reply.code(500).send({ error: "Internal Server Error" });
+      }
+    },
+  );
+};
+
+export default reminder;

--- a/server/src/schemas/reminder.ts
+++ b/server/src/schemas/reminder.ts
@@ -1,0 +1,11 @@
+import z from "zod";
+
+export const createReminderSchema = z.object({
+  title: z.string().min(1, "Title is required").max(100, "Title too long"),
+  note: z.string().max(500, "Note too long").optional(),
+  due_at: z.string().datetime("Invalid date format"),
+  repeat: z.enum(["NONE", "DAILY", "WEEKLY", "MONTHLY"], {
+    errorMap: () => ({ message: "Invalid repeat value" }),
+  }),
+  is_done: z.boolean().default(false),
+});


### PR DESCRIPTION
📋 Description  
This PR introduces the Reminder APIs, enabling users to create, view, update, and delete reminders. These endpoints support the reminders feature on the frontend and allow users to schedule and manage upcoming reminders efficiently.

✅ Key Changes  
API Implementation: Implemented CRUD endpoints for reminders (`POST`, `GET`, `PATCH`, `DELETE`).  
Database Model: Added the `Reminder` model in Prisma with fields for `id`, `userId`, `title`, `note`, `remindAt`, and timestamps.  
Validation: Implemented request validation using Zod schemas to ensure valid reminder data.  
Authorization: Ensured reminders are scoped to the authenticated user using `userId`.  

Closes #87 