### PR TITLE
Fix CORS error

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -32,13 +32,11 @@ export function buildApp() {
   });
 
   app.register(helmet);
-  // app.register(cors, {
-  //   origin: (origin, cb) => {
-  //     // Accept all in dev; set a proper allowlist for prod
-  //     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-  //     cb(null, true);
-  //   },
-  // });
+  app.register(cors, {
+    origin: ["https://spndo.app"],
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    credentials: true,
+  });
 
   app.register(jwtPlugin);
   app.register(health, { prefix: "/" });


### PR DESCRIPTION
This pull request updates the CORS configuration in the `buildApp` function to restrict allowed origins and enable credentials. The change ensures that only requests from the production frontend are accepted, improving security.

**Security and configuration updates:**

* Updated the CORS middleware in `server/src/app.ts` to only allow requests from `https://spndo.app`, specify allowed HTTP methods, and enable credentials. This replaces the previous (commented out) permissive configuration.